### PR TITLE
ix.data.Set(key, value, bGlobal, bIgnoreMap)

### DIFF
--- a/snippets/libraries.json
+++ b/snippets/libraries.json
@@ -314,7 +314,7 @@
     "ix.data.Set": {
         "prefix": "ix.data.Set",
         "body": [
-            "ix.data.Set(${1:key}, ${2:default}, ${3:bGlobal}, ${4:bIgnoreMap})$0"
+            "ix.data.Set(${1:key}, ${2:value}, ${3:bGlobal}, ${4:bIgnoreMap})$0"
         ],
         "description": "Populates a file in the data/helix folder with some serialized data."
     },


### PR DESCRIPTION
Change "ix.data.Set(key, default, bGlobal, bIgnoreMap)" to "ix.data.Set(key, value, bGlobal, bIgnoreMap)".